### PR TITLE
Remove some docker compose warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-#FROM ubuntu:20.04 as base
-FROM docker.io/node:18.19.1-bullseye as base
+#FROM ubuntu:20.04 AS base
+FROM docker.io/node:18.19.1-bullseye AS base
 
 ARG LOADDIR="/load-agent"
 
@@ -36,7 +36,7 @@ RUN apt-get install -y python3-pip
 
 RUN pip3 install locust==2.14.2
 
-FROM base as dev
+FROM base AS dev
 
 # Setup Dev environment
 RUN apt-get install -y tmux htop
@@ -46,7 +46,7 @@ ARG LOADDIR
 # Set working directory to function root directory
 WORKDIR ${LOADDIR}
 
-FROM base as release
+FROM base AS release
 
 # Include global arg in this stage of the build
 ARG LOADDIR

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
 
   load-agent:


### PR DESCRIPTION
Very minor, but get some warnings when running `docker compose build`

Adjust casing
![image](https://github.com/user-attachments/assets/cc7c2423-f589-4c1b-8041-553ce156cc89)

Remove [deprecated ](https://github.com/docker/compose/issues/11628?form=MG0AV3) `version`
![image](https://github.com/user-attachments/assets/66744cd2-068e-4ade-abff-993eb070393e)
