### PR TITLE
feat: add docs, config, and scripts for vdr proxy load tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 load-agent/node_modules
 load-agent/__pycache__
+load-vdr-proxy/__pycache__
 .env
 aries-framework-javascript
 *.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #FROM ubuntu:20.04 AS base
-FROM docker.io/node:18.19.1-bullseye AS base
+FROM docker.io/node:18.20.7-bullseye AS base
 
 ARG LOADDIR="/load-agent"
 

--- a/Dockerfile.vdr
+++ b/Dockerfile.vdr
@@ -1,0 +1,37 @@
+FROM docker.io/node:18.20.7-bullseye AS base
+
+ARG LOADDIR="/load-vdr-proxy"
+
+ENV TZ=America/Denver
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update -y && apt-get install -y curl gcc g++ make git libssl-dev pkg-config
+
+# Setup Locust
+
+RUN apt-get install -y python3-pip
+
+RUN pip3 install locust==2.14.2
+
+FROM base AS dev
+
+# Setup Dev environment
+RUN apt-get install -y tmux htop
+
+# Include global arg in this stage of the build
+ARG LOADDIR
+# Set working directory to function root directory
+WORKDIR ${LOADDIR}
+
+FROM base AS release
+
+# Include global arg in this stage of the build
+ARG LOADDIR
+# Set working directory to function root directory
+WORKDIR ${LOADDIR}
+
+ADD ./load-vdr-proxy load-vdr-proxy
+
+WORKDIR ${LOADDIR}/load-vdr-proxy
+
+CMD "locust"

--- a/docker-compose.vdr-local.yml
+++ b/docker-compose.vdr-local.yml
@@ -1,19 +1,20 @@
-version: '3'
 services:
 
-  load-agent:
+  load-vdr-proxy:
     build:
       context: .
-      target: dev
-    hostname: load-agent
+      target: release
+      dockerfile: ./Dockerfile.vdr
+    hostname: load-vdr-proxy
     restart: unless-stopped
     user: root 
     tty: true
     command: >
-      locust -f ${LOCUST_FILES}
+      locust -f ${LOCUST_FILES} 
     ports:
-      - "${START_PORT}-${END_PORT}:${START_PORT}-${END_PORT}"
       - "8089:8089"
+      - "8090:8090"
+      - "${START_PORT}-${END_PORT}:${START_PORT}-${END_PORT}"
     environment: 
       - NODE_ENV=${NODE_ENV}
       - BROWSER=none  # don't open the web browser
@@ -37,12 +38,16 @@ services:
       - VERIFIED_TIMEOUT_SECONDS=${VERIFIED_TIMEOUT_SECONDS}
       - WITH_MEDIATION=${WITH_MEDIATION}
       - OOB_INVITE=${OOB_INVITE}
-    volumes:
-      - ./load-agent:/load-agent:rw
+      - VDR_BASE_URL=${VDR_BASE_URL}
+      - VDR_CRED_DEF=${VDR_CRED_DEF}
+      - VDR_SCHEMA=${VDR_SCHEMA}
+      - VDR_DID=${VDR_DID}
+      - VDR_REV_REG_DEF=${VDR_REV_REG_DEF}
     networks:
       - app-network
 
 # Docker Networks
 networks:
   app-network:
-    driver: bridge
+    name: vdr-load-test
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     networks:
       - app-network
 
-#Docker Networks
+# Docker Networks
 networks:
   app-network:
     driver: bridge

--- a/docs/VDR.md
+++ b/docs/VDR.md
@@ -1,0 +1,46 @@
+# Load testing Indy VDR Proxy
+
+This README is documentation for setting up and running Locust load tests of Indy VDR proxies based on this package [here](https://github.com/2060-io/credo-ts-indy-vdr-proxy/tree/main/packages/server) such as the following BC Gov implementation [here.](https://github.com/bcgov/indy-vdr-proxy-server)
+
+## Running load tests locally
+
+You will need to clone two repos, this one and your chosen proxy server. We will use the BC Gov repo mentioned above as an example.
+
+Ensure you have Docker setup on your machine and enough space for some fairly hefty images. 
+
+Copy `sample.vdr.env` to `.env` and replace with values that fit for your use case - especially confirm that the schemas, cred defs, revocation registry definitions, and dids you are providing exist on the ledgers your Indy VDR Proxy Server connects to.
+
+From the Indy VDR Proxy Server repo, run the following two commands:
+
+```sh
+docker build --no-cache --tag 'proxy' .
+```
+```sh
+docker run --name vdr-proxy -p 3000:3000 --network vdr-load-test 'proxy'
+```
+These flags are necessary to more easily target the local proxy externally.
+
+Next, from the root of this repo, execute the following command:
+```sh
+docker compose -f docker-compose.vdr-local.yml up --build
+```
+
+The `--build` flag helps prevent caching issues if you are doing development.
+
+Finally, navigate to `http://0.0.0.0:8089`. You should see  choose your desired settings (num of users, spawn rate, you can leave host blank), then click "Start swarming"
+
+When you are satisfied with the results, stop the test and feel free to download your results. That being said, for more accurate tests, you should run against a deployed version of your proxy server with the same resource allocation as your intended prod deployment.
+
+**NOTES:**
+If your proxy server includes a rate limiter, you may need to disable or greatly alter it for tests with higher numbers of simulated users.
+
+As a very rough benchmark, running the VDR load tests against the BC Gov repo in a single container on an Intel Mac, spawning 50 users per second until reaching 500 users achieved the following results:
+| Test Script                        | Average Request Time (ms) | RPS  | Average Size (bytes) | Failures/s |
+|------------------------------------|---------------------------|------|----------------------|------------|
+| locustIndyVDRProxyCredDef.py       | 113                       | 90.1 | 12865                | 0.0        |
+| locustIndyVDRProxyDID.py           | 21                        | 90.9 | 1374                 | 0.0        |
+| locustIndyVDRProxyRevRegDef.py     | 19                        | 92.1 | 1540                 | 0.0        |
+| locustIndyVDRProxyRevStatusList.py | 32                        | 88.4 | 5607                 | 48.3       |
+| locustIndyVDRProxySchema.py        | 20                        | 88.6 | 375                  | 0.0        |
+
+As you can see from these results, it isn't recommended to use the `locustIndyVDRRevStatusList` load test script as it depends on a timestamp and the results currently can't be cached. This results in many repeated lookups on the ledger which will eventually block the IP of your proxy for spamming.

--- a/load-agent/constants.py
+++ b/load-agent/constants.py
@@ -1,0 +1,4 @@
+from locust import between
+import os
+
+standard_wait = between(float(os.getenv('LOCUST_MIN_WAIT', 0.1)), float(os.getenv('LOCUST_MAX_WAIT', 1)))

--- a/load-agent/locustClient.py
+++ b/load-agent/locustClient.py
@@ -1,21 +1,15 @@
 from locust import events
-from json.decoder import JSONDecodeError
 import time
 import inspect
 import json
 
-from typing import Any, Optional
-
-import fcntl
 import os
-import requests
 import signal
 
 from gevent import subprocess
 from gevent import select
 from gevent import lock as gevent_lock
 
-from uuid import uuid4
 
 SHUTDOWN_TIMEOUT_SECONDS = 10
 READ_TIMEOUT_SECONDS = 120  # stdout feedback

--- a/load-agent/locustFractionMediatorIssueVerify.py
+++ b/load-agent/locustFractionMediatorIssueVerify.py
@@ -1,12 +1,8 @@
-from locust import SequentialTaskSet, task, User, between
+from locust import SequentialTaskSet, task, User
 from locustClient import CustomClient
-import time
-import inspect
-import json
+from constants import standard_wait
 
-import fcntl
 import os
-import signal
 
 WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
@@ -51,6 +47,6 @@ class UserBehaviour(SequentialTaskSet):
 
 class Issue(CustomLocust):
     tasks = [UserBehaviour]
-    wait_time = between(float(os.getenv('LOCUST_MIN_WAIT',0.1)), float(os.getenv('LOCUST_MAX_WAIT',1)))
+    wait_time = standard_wait
 #    host = "example.com"
 

--- a/load-agent/locustLiveness.py
+++ b/load-agent/locustLiveness.py
@@ -1,12 +1,6 @@
 from locust import SequentialTaskSet, task, User, between
 from locustClient import CustomClient
-import time
-import inspect
-import json
-
-import fcntl
-import os
-import signal
+from constants import standard_wait
 
 class CustomLocust(User):
     abstract = True
@@ -27,5 +21,5 @@ class UserBehaviour(SequentialTaskSet):
 
 class Liveness(CustomLocust):
     tasks = [UserBehaviour]
-    wait_time = between(float(os.getenv('LOCUST_MIN_WAIT',0.1)), float(os.getenv('LOCUST_MAX_WAIT',1)))
+    wait_time = standard_wait
 #    host = "example.com"

--- a/load-agent/locustMediatorIssue.py
+++ b/load-agent/locustMediatorIssue.py
@@ -1,12 +1,8 @@
 from locust import SequentialTaskSet, task, User, between
 from locustClient import CustomClient
-import time
-import inspect
-import json
+from constants import standard_wait
 
-import fcntl
 import os
-import signal
 
 WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
@@ -43,5 +39,5 @@ class UserBehaviour(SequentialTaskSet):
 
 class Issue(CustomLocust):
     tasks = [UserBehaviour]
-    wait_time = between(float(os.getenv('LOCUST_MIN_WAIT',0.1)), float(os.getenv('LOCUST_MAX_WAIT',1)))
+    wait_time = standard_wait
 #    host = "example.com"

--- a/load-agent/locustMediatorIssueRevoke.py
+++ b/load-agent/locustMediatorIssueRevoke.py
@@ -1,12 +1,8 @@
-from locust import SequentialTaskSet, task, User, between
+from locust import SequentialTaskSet, task, User
 from locustClient import CustomClient
-import time
-import inspect
-import json
+from constants import standard_wait
 
-import fcntl
 import os
-import signal
 
 WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
@@ -49,5 +45,5 @@ class UserBehaviour(SequentialTaskSet):
 
 class IssueRevoke(CustomLocust):
     tasks = [UserBehaviour]
-    wait_time = between(float(os.getenv('LOCUST_MIN_WAIT',0.1)), float(os.getenv('LOCUST_MAX_WAIT',1)))
+    wait_time = standard_wait
 #    host = "example.com"

--- a/load-agent/locustMediatorMsg.py
+++ b/load-agent/locustMediatorMsg.py
@@ -1,12 +1,8 @@
-from locust import SequentialTaskSet, task, User, between
+from locust import SequentialTaskSet, task, User
 from locustClient import CustomClient
-import time
-import inspect
-import json
+from constants import standard_wait
 
-import fcntl
 import os
-import signal
 
 WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
@@ -45,5 +41,5 @@ class UserBehaviour(SequentialTaskSet):
 
 class MediatorMsg(CustomLocust):
     tasks = [UserBehaviour]
-    wait_time = between(float(os.getenv('LOCUST_MIN_WAIT',0.1)), float(os.getenv('LOCUST_MAX_WAIT',1)))
+    wait_time = standard_wait
 #    host = "example.com"

--- a/load-agent/locustMediatorPing.py
+++ b/load-agent/locustMediatorPing.py
@@ -1,12 +1,8 @@
-from locust import TaskSet, task, User, between
+from locust import TaskSet, task, User
 from locustClient import CustomClient
-import time
-import inspect
-import json
+from constants import standard_wait
 
-import fcntl
 import os
-import signal
 
 WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
@@ -31,5 +27,5 @@ class UserBehaviour(TaskSet):
 
 class MediatorPing(CustomLocust):
     tasks = [UserBehaviour]
-    wait_time = between(float(os.getenv('LOCUST_MIN_WAIT',0.1)), float(os.getenv('LOCUST_MAX_WAIT',1)))
+    wait_time = standard_wait
 #    host = "example.com"

--- a/load-agent/locustMediatorPresentProof.py
+++ b/load-agent/locustMediatorPresentProof.py
@@ -1,12 +1,8 @@
-from locust import SequentialTaskSet, task, User, between
+from locust import SequentialTaskSet, task, User
 from locustClient import CustomClient
-import time
-import inspect
-import json
+from constants import standard_wait
 
-import fcntl
 import os
-import signal
 
 WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
@@ -63,6 +59,6 @@ class UserBehaviour(SequentialTaskSet):
 
 class Issue(CustomLocust):
     tasks = [UserBehaviour]
-    wait_time = between(float(os.getenv('LOCUST_MIN_WAIT',0.1)), float(os.getenv('LOCUST_MAX_WAIT',1)))
+    wait_time = standard_wait
 #    host = "example.com"
 

--- a/load-agent/locustMediatorPresentProofExisting.py
+++ b/load-agent/locustMediatorPresentProofExisting.py
@@ -1,12 +1,8 @@
-from locust import SequentialTaskSet, task, User, between
+from locust import SequentialTaskSet, task, User
 from locustClient import CustomClient
-import time
-import inspect
-import json
+from constants import standard_wait
 
-import fcntl
 import os
-import signal
 
 WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
@@ -88,6 +84,4 @@ class UserBehaviour(SequentialTaskSet):
 
 class Issue(CustomLocust):
     tasks = [UserBehaviour]
-    wait_time = between(
-        float(os.getenv("LOCUST_MIN_WAIT", 0.1)), float(os.getenv("LOCUST_MAX_WAIT", 1))
-    )
+    wait_time = standard_wait

--- a/load-vdr-proxy/constants.py
+++ b/load-vdr-proxy/constants.py
@@ -1,0 +1,4 @@
+from locust import between
+import os
+
+standard_wait = between(float(os.getenv('LOCUST_MIN_WAIT', 0.1)), float(os.getenv('LOCUST_MAX_WAIT', 1)))

--- a/load-vdr-proxy/locustIndyVDRProxyCredDef.py
+++ b/load-vdr-proxy/locustIndyVDRProxyCredDef.py
@@ -1,0 +1,34 @@
+from locust import task, HttpUser
+from constants import standard_wait
+import os
+from string import Template
+from urllib.parse import quote
+
+global template
+global base_url
+global cred_def
+global url
+template = Template('/credential-definition/$creddef')
+base_url = os.getenv('VDR_BASE_URL')
+cred_def = os.getenv('VDR_CRED_DEF')
+url = quote(template.substitute(creddef=cred_def))
+
+class IndyVDRProxyCredDefLookup(HttpUser):
+    wait_time = standard_wait
+    host = base_url
+
+    @task
+    def lookup_cred_def(self):
+        with self.client.get(url, headers={"Connection": "close"}, verify=False, catch_response=True) as response:
+            try:
+                data = response.json()
+                cdid = data['credentialDefinitionId']
+                if cdid == cred_def:
+                    response.success()
+                else:
+                    print("Incorrect response")
+                    response.failure("Incorrect response")
+            except Exception as e:
+                print("Error thrown")
+                print(e)
+                response.failure("Error thrown")

--- a/load-vdr-proxy/locustIndyVDRProxyDID.py
+++ b/load-vdr-proxy/locustIndyVDRProxyDID.py
@@ -1,0 +1,37 @@
+from locust import task, HttpUser
+from constants import standard_wait
+import os
+from string import Template
+from urllib.parse import quote
+
+global template
+global base_url
+global did
+global url
+template = Template('/did/$did')
+base_url = os.getenv('VDR_BASE_URL')
+did = os.getenv('VDR_DID')
+url = quote(template.substitute(did=did))
+
+class IndyVDRProxyDIDLookup(HttpUser):
+    wait_time = standard_wait
+    host = base_url
+
+    @task
+    def lookup_did(self):
+        with self.client.get(url, headers={"Connection": "close"}, verify=False, catch_response=True) as response:
+            try:
+                data = response.json()
+                # there are a variety of did formats. using the base did in the .env file 
+                # (only the id, no prefix) helps ensure there are no false negatives from
+                # the check below
+                d = data['didDocument']['id']
+                if did in d:
+                    response.success()
+                else:
+                    print("Incorrect response")
+                    response.failure("Incorrect response")
+            except Exception as e:
+                print("Error thrown")
+                print(e)
+                response.failure("Error thrown")

--- a/load-vdr-proxy/locustIndyVDRProxyRevRegDef.py
+++ b/load-vdr-proxy/locustIndyVDRProxyRevRegDef.py
@@ -1,0 +1,34 @@
+from locust import task, HttpUser
+from constants import standard_wait
+import os
+from string import Template
+from urllib.parse import quote
+
+global template
+global base_url
+global rev_reg_def
+global url
+template = Template('/revocation-registry-definition/$revregdef')
+base_url = os.getenv('VDR_BASE_URL')
+rev_reg_def = os.getenv('VDR_REV_REG_DEF')
+url = quote(template.substitute(revregdef=rev_reg_def))
+
+class IndyVDRProxyRevRegDefLookup(HttpUser):
+    wait_time = standard_wait
+    host = base_url
+
+    @task
+    def lookup_rev_reg_def(self):
+        with self.client.get(url, headers={"Connection": "close"}, verify=False, catch_response=True) as response:
+            try:
+                data = response.json()
+                rrd = data['revocationRegistryDefinitionId']
+                if rrd == rev_reg_def:
+                    response.success()
+                else:
+                    print("Incorrect response")
+                    response.failure("Incorrect response")
+            except Exception as e:
+                print("Error thrown")
+                print(e)
+                response.failure("Error thrown")

--- a/load-vdr-proxy/locustIndyVDRProxyRevStatusList.py
+++ b/load-vdr-proxy/locustIndyVDRProxyRevStatusList.py
@@ -1,0 +1,37 @@
+from locust import task, HttpUser
+from constants import standard_wait
+import os
+from time import time
+from string import Template
+from urllib.parse import quote
+
+global template
+global base_url
+global rev_reg_def
+global ts
+global url
+template = Template('/revocation-status-list/$revregdef/$timestamp')
+base_url = os.getenv('VDR_BASE_URL')
+rev_reg_def = os.getenv('VDR_REV_REG_DEF')
+ts = time()
+url = quote(template.substitute(revregdef=rev_reg_def, timestamp=ts))
+
+class IndyVDRProxyRevStatusListLookup(HttpUser):
+    wait_time = standard_wait
+    host = base_url
+
+    @task
+    def lookup_rev_status_list(self):
+        with self.client.get(url, headers={"Connection": "close"}, verify=False, catch_response=True) as response:
+            try:
+                data = response.json()
+                rrd = data['revocationStatusList']['revRegDefId']
+                if rrd == rev_reg_def:
+                    response.success()
+                else:
+                    print("Incorrect response")
+                    response.failure("Incorrect response")
+            except Exception as e:
+                print("Error thrown")
+                print(e)
+                response.failure("Error thrown")

--- a/load-vdr-proxy/locustIndyVDRProxySchema.py
+++ b/load-vdr-proxy/locustIndyVDRProxySchema.py
@@ -1,0 +1,34 @@
+from locust import task, HttpUser
+from constants import standard_wait
+import os
+from string import Template
+from urllib.parse import quote
+
+global template
+global base_url
+global schema
+global url
+template = Template('/schema/$schemaid')
+base_url = os.getenv('VDR_BASE_URL')
+schema = os.getenv('VDR_SCHEMA')
+url = quote(template.substitute(schemaid=schema))
+
+class IndyVDRProxySchemaLookup(HttpUser):
+    wait_time = standard_wait
+    host = base_url
+
+    @task
+    def lookup_schema(self):
+        with self.client.get(url, headers={"Connection": "close"}, verify=False, catch_response=True) as response:
+            try:
+                data = response.json()
+                sid = data['schemaId']
+                if sid == schema and int(response.status_code) in range(200, 300):
+                    response.success()
+                else:
+                    print("Incorrect response")
+                    response.failure("Incorrect response")
+            except Exception as e:
+                print("Error thrown")
+                print(e)
+                response.failure("Error thrown")

--- a/master.docker-compose.yml
+++ b/master.docker-compose.yml
@@ -41,7 +41,7 @@ services:
     networks:
       - app-network
 
-#Docker Networks
+# Docker Networks
 networks:
   app-network:
     driver: bridge

--- a/sample.vdr.env
+++ b/sample.vdr.env
@@ -1,0 +1,44 @@
+# docker-compose.yml commands won't work out of the box - 
+# please make sure to update the command according to your environment.
+MEDIATION_URL=https://1d9d-38-18-133-247.ngrok-free.app?c_i=eyJAdHlwZSI6ICJodHRwczovL2RpZGNvbW0ub3JnL2Nvbm5lY3Rpb25zLzEuMC9pbnZpdGF0aW9uIiwgIkBpZCI6ICI4ODA2NzJmMC1iNTM2LTQwOTAtYTA1Yi02ZGY5MjJlODA4NWYiLCAibGFiZWwiOiAiTWVkaWF0b3IiLCAicmVjaXBpZW50S2V5cyI6IFsiSHVnUWljWk5BUjZCMzVLTUpxY1FuM3FpVXFzcW14YmNtb0x0TXdRWGt4VDYiXSwgInNlcnZpY2VFbmRwb2ludCI6ICJodHRwczovLzFkOWQtMzgtMTgtMTMzLTI0Ny5uZ3Jvay1mcmVlLmFwcCJ9
+
+# If clustered environment
+MASTER_HOST= # external ip
+MASTER_PORT=8089
+AGENT_IP= # external ip (load balancer if clustered)
+
+# Period an agent will wait before running another ping
+LOCUST_MIN_WAIT=1
+LOCUST_MAX_WAIT=10
+
+ISSUER_URL=http:// #ACA-Py admin interface
+ISSUER_TYPE="acapy"
+ISSUER_HEADERS={"Authorization":"Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ3YWxsZXRfaWQiOiIwOWY5ZDAwNC02OTM0LTQyZDYtOGI4NC1jZTY4YmViYzRjYTUiLCJpYXQiOjE2NzY4NDExMTB9.pDQPjiYEAoDJf3044zbsHrSjijgS-yC8t-9ZiuC08x8"}
+
+VERIFIER_URL=http:// #ACA-Py admin interface
+VERIFIER_TYPE="acapy"
+VERIFIER_HEADERS={"Authorization":"Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ3YWxsZXRfaWQiOiIwOWY5ZDAwNC02OTM0LTQyZDYtOGI4NC1jZTY4YmViYzRjYTUiLCJpYXQiOjE2NzY4NDExMTB9.pDQPjiYEAoDJf3044zbsHrSjijgS-yC8t-9ZiuC08x8"}
+
+
+CRED_DEF= # anchor cred def
+LEDGER=bcovrin # or candy or whichever ledger is your preference
+CRED_ATTR='[{"mime-type": "text/plain","name": "score","value": "test"}]'
+SCHEMA= # anchor schema
+VERIFIED_TIMEOUT_SECONDS=60 # seconds for verified: true
+
+WITH_MEDIATION = False
+LOCUST_FILES=locustIndyVDRProxyCredDef.py
+
+# Increase the END_PORT if you want to run a lot of agents in parallel
+# If doing large clustering, it is recommended to increase ports exposed
+START_PORT=10000
+END_PORT=10500
+
+MESSAGE_TO_SEND="Lorem ipsum dolor sit amet consectetur, adipiscing elit nisi aptent rutrum varius, class non nullam etiam. Ac purus donec morbi litora vivamus nec semper suscipit vehicula, aliquet parturient leo mollis in mauris quis nisi tincidunt, sociis accumsan senectus pellentesque erat cras sociosqu phasellus augue, posuere ligula scelerisque tempus dapibus enim torquent facilisi. Imperdiet gravida justo conubia congue senectus porta vivamus netus rhoncus nec, mauris tristique semper feugiat natoque nunc nibh montes dapibus proin, egestas luctus sollicitudin maecenas malesuada pharetra eleifend nam ultrices. Iaculis fringilla penatibus dictumst varius enim elementum justo senectus, pretium mauris cum vel tempor gravida lacinia auctor a, cursus sed euismod scelerisque vivamus netus aenean. Montes iaculis dui platea blandit mattis nec urna, diam ridiculus augue tellus vivamus justo nulla, auctor hendrerit aenean arcu venenatis tristique feugiat, odio pellentesque purus nascetur netus fringilla. S."
+
+# Configuration for Indy VDR Proxy load tests
+VDR_BASE_URL=http://vdr-proxy:3000
+VDR_CRED_DEF=RGjWbW1eycP7FrMf4QJvX8:3:CL:13:Person
+VDR_SCHEMA=RGjWbW1eycP7FrMf4QJvX8:2:Person:1.0
+VDR_DID=RGjWbW1eycP7FrMf4QJvX8
+VDR_REV_REG_DEF=RGjWbW1eycP7FrMf4QJvX8:4:RGjWbW1eycP7FrMf4QJvX8:3:CL:13:Person:CL_ACCUM:cd48fe2a-8ed1-4f35-8564-179cfce4cc70

--- a/worker.docker-compose.yml
+++ b/worker.docker-compose.yml
@@ -42,7 +42,7 @@ services:
     networks:
       - app-network
 
-#Docker Networks
+# Docker Networks
 networks:
   app-network:
     driver: bridge


### PR DESCRIPTION
Following up after issue #90, this PR adds load test scripts for Indy VDR proxy servers that are based on [this package](https://github.com/2060-io/credo-ts-indy-vdr-proxy/tree/main/packages/server). More in-depth details are available in the VDR addition to the `docs` folder. The main changes in this PR:
- add load testing scripts for above-mentioned proxy server into a new dir `load-vdr-proxy`
- small refactor to reduce some duplication (`standard_wait`) and remove unused imports
- added sample env for VDR
- added docker compose and Dockerfile specifically for VDR
- added docs, including some loose results from local runs
- updated the node image by a minor version (still specified patch version) because it seems the previous image was no longer supported

The nice thing about testing this server is that I was able to do it with just Locust - I'm not really using Akrida, so it's a bit similar. But because they are so closely related this repo is probably still a good place to add them to.

Relevant: bcgov/bc-wallet-mobile#2245

Feedback welcome :)