### PR TITLE
Add config for pickup strategy change

### DIFF
--- a/load-agent/agent.ts
+++ b/load-agent/agent.ts
@@ -13,7 +13,6 @@ import {
   IndyVdrIndyDidResolver,
   IndyVdrModule,
   IndyVdrIndyDidRegistrar,
-  IndyVdrPoolConfig,
 } from '@credo-ts/indy-vdr'
 
 // var indySdk = require('indy-sdk')
@@ -30,18 +29,12 @@ import {
   CredentialsModule,
   V2CredentialProtocol,
   ConnectionsModule,
-  W3cCredentialsModule,
   KeyDidRegistrar,
   KeyDidResolver,
-  CacheModule,
-  InMemoryLruCache,
   WebDidResolver,
   HttpOutboundTransport,
   WsOutboundTransport,
-  LogLevel,
   Agent,
-  JsonLdCredentialFormatService,
-  DifPresentationExchangeProofFormatService,
   MediationRecipientModule,
   MediatorPickupStrategy,
 
@@ -61,7 +54,7 @@ import {
 import { anoncreds } from '@hyperledger/anoncreds-nodejs'
 import { ariesAskar } from '@hyperledger/aries-askar-nodejs'
 import { indyVdr } from '@hyperledger/indy-vdr-nodejs'
-import { agentDependencies, HttpInboundTransport, WsInboundTransport } from '@credo-ts/node'
+import { agentDependencies, HttpInboundTransport } from '@credo-ts/node'
 
 var config = require('./config.js')
 
@@ -127,7 +120,7 @@ const initializeAgent = async (withMediation, port, agentConfig = null) => {
     // }),
     mediationRecipient: new MediationRecipientModule({
       mediatorInvitationUrl: mediation_url,
-      mediatorPickupStrategy: MediatorPickupStrategy.Implicit,
+      mediatorPickupStrategy: MediatorPickupStrategy.Implicit,      
     }),
     anoncreds: new AnonCredsModule({
       registries: [new IndyVdrAnonCredsRegistry()],
@@ -227,6 +220,14 @@ const initializeAgent = async (withMediation, port, agentConfig = null) => {
 
     // Initialize the agent
     await agent.initialize()
+
+    if (config.pickup_strategy === 'pickupv2-live') {
+      process.stderr.write('Pickup strategy: pickupv2-live')
+      await agent.mediationRecipient.initiateMessagePickup(
+        undefined,
+        MediatorPickupStrategy.PickUpV2LiveMode
+      )
+    }
 
     // wait for ws to be configured
     let value = await Promise.race([TimeDelay, def.promise])

--- a/load-agent/config.js
+++ b/load-agent/config.js
@@ -40,3 +40,4 @@ exports.mediation_url = process.env.MEDIATION_URL;
 exports.agent_ip = process.env.AGENT_IP;
 exports.verified_timeout_seconds = (process.env.VERIFIED_TIMEOUT_SECONDS || 120)
 exports.ledger = ledger;
+exports.pickup_strategy = (process.env.PICKUP_STRATEGY || "implicit").toLowerCase();

--- a/sample.env
+++ b/sample.env
@@ -40,3 +40,7 @@ START_PORT=10000
 END_PORT=10500
 
 MESSAGE_TO_SEND="Lorem ipsum dolor sit amet consectetur, adipiscing elit nisi aptent rutrum varius, class non nullam etiam. Ac purus donec morbi litora vivamus nec semper suscipit vehicula, aliquet parturient leo mollis in mauris quis nisi tincidunt, sociis accumsan senectus pellentesque erat cras sociosqu phasellus augue, posuere ligula scelerisque tempus dapibus enim torquent facilisi. Imperdiet gravida justo conubia congue senectus porta vivamus netus rhoncus nec, mauris tristique semper feugiat natoque nunc nibh montes dapibus proin, egestas luctus sollicitudin maecenas malesuada pharetra eleifend nam ultrices. Iaculis fringilla penatibus dictumst varius enim elementum justo senectus, pretium mauris cum vel tempor gravida lacinia auctor a, cursus sed euismod scelerisque vivamus netus aenean. Montes iaculis dui platea blandit mattis nec urna, diam ridiculus augue tellus vivamus justo nulla, auctor hendrerit aenean arcu venenatis tristique feugiat, odio pellentesque purus nascetur netus fringilla. S."
+
+# If you want to use a different pickup strategy, you can set it here
+# The default is 'implicit', but you can also use 'pickupv2-live'
+PICKUP_STRATEGY='implicit' # or 'pickupv2-live'


### PR DESCRIPTION
Adds a config/env variable to allow the load-agent to change to pickupv2 live mode after agent initialization.

Removes some unused imports.