### PR TITLE
V2 issuance/presentation agents

### DIFF
--- a/load-agent/agent.ts
+++ b/load-agent/agent.ts
@@ -15,14 +15,9 @@ import {
   IndyVdrIndyDidRegistrar,
 } from '@credo-ts/indy-vdr'
 
-// var indySdk = require('indy-sdk')
-import { AskarModule, AskarMultiWalletDatabaseScheme } from '@credo-ts/askar'
-// import { ariesAskar } from '@hyperledger/aries-askar-react-native'
-// import { AskarModule } from '@aries-framework/askar'
+import { AskarModule } from '@credo-ts/askar'
 
 import {
-  AutoAcceptCredential,
-  AutoAcceptProof,
   DidsModule,
   ProofsModule,
   V2ProofProtocol,
@@ -37,10 +32,8 @@ import {
   Agent,
   MediationRecipientModule,
   MediatorPickupStrategy,
-
   CredentialEventTypes,
   ProofEventTypes,
-  MediatorModule,
   DidCommMimeType,
   TransportEventTypes,
   TrustPingEventTypes,
@@ -180,7 +173,7 @@ const initializeAgent = async (withMediation, port, agentConfig = null) => {
     agent.registerOutboundTransport(httpTransport)
 
   if (withMediation) {
-    // wait for medation to be configured
+    // wait for mediation to be configured
     let timeout = config.verified_timeout_seconds * 1000
 
     const TimeDelay = new Promise((resolve, reject) => {
@@ -250,7 +243,7 @@ const initializeAgent = async (withMediation, port, agentConfig = null) => {
 
   } catch (error) {
 
-    process.stderr.write('******** ERROR Error at intialize agent'+ '\n' + error + '\n')
+    process.stderr.write('******** ERROR Error at initialize agent'+ '\n' + error + '\n')
   }
   
 }
@@ -294,7 +287,7 @@ const pingMediator = async (agent) => {
     await agent.connections.sendPing(mediatorConnection.id, {})
   }
 
-  // wait for ping repsonse
+  // wait for ping response
   let value = await Promise.race([TimeDelay, def.promise])
 
   if (!value) {

--- a/load-agent/agents/base.py
+++ b/load-agent/agents/base.py
@@ -1,0 +1,53 @@
+from abc import ABC
+
+import requests
+from settings import Settings
+
+
+class BaseAgent(ABC):
+    def __init__(self):
+        print("BaseAgent initialized")
+        self.agent_url = Settings.ISSUER_URL
+        self.headers = Settings.ISSUER_HEADERS | {"Content-Type": "application/json"}
+
+    def get_invite(self):                    
+        r = requests.post(
+            f"{self.agent_url}/out-of-band/create-invitation?auto_accept=true",
+            json={"handshake_protocols": Settings.HANDSHAKE_PROTOCOLS},
+            headers=self.headers,
+        )
+        invitation = r.json()
+        
+        r = requests.get(
+            f"{self.agent_url}/connections",
+            params={"invitation_msg_id": invitation["invi_msg_id"]},
+            headers=self.headers,
+        )
+        connection = r.json()["results"][0]
+        
+        return {
+            "invitation_url": invitation["invitation_url"],
+            "connection_id": connection["connection_id"],
+        }
+
+    def is_up(self):
+        try:
+            r = requests.get(
+                f"{self.agent_url}/status",
+                headers=self.headers,
+            )
+            if r.status_code != 200:
+                raise Exception(r.content)
+
+            r.json()
+        except Exception:
+            return False
+
+        return True
+
+    def send_message(self, connection_id, msg):
+        requests.post(
+            f"{self.agent_url}/connections/{connection_id}/send-message",
+            json={"content": msg},
+            headers=self.headers,
+        )

--- a/load-agent/agents/issuer/acapy_v2.py
+++ b/load-agent/agents/issuer/acapy_v2.py
@@ -1,0 +1,56 @@
+import time
+
+import requests
+from models import (
+    AnonCredsFilter,
+    AnonCredsRevocation,
+    CredentialPreview,
+    Filter,
+)
+from models import (
+    IssueCredentialV2 as IssueCredential,
+)
+from settings import Settings
+
+from .base import BaseIssuer
+
+
+class AcapyIssuer(BaseIssuer):
+    def __init__(self):
+        print("AcapyIssuer initialized")
+        super().__init__()
+        self.filter = Settings.FILTER_TYPE
+
+    def issue_credential(self, connection_id):
+        r = requests.post(
+            f"{self.agent_url}/issue-credential-2.0/send",
+            headers=self.headers,
+            json=IssueCredential(
+                connection_id=connection_id,
+                credential_preview=CredentialPreview(attributes=self.cred_attributes),
+                filter=AnonCredsFilter(anoncreds=Filter(cred_def_id=self.cred_def_id)),
+            ).model_dump(),
+        )
+        if r.status_code != 200:
+            raise Exception(r.content)
+
+        cred_ex = r.json()
+
+        return {
+            "connection_id": cred_ex["connection_id"],
+            "cred_ex_id": cred_ex["credential_exchange_id"],
+        }
+
+    def revoke_credential(self, connection_id, cred_ex_id):
+        time.sleep(1)
+        r = requests.post(
+            f"{self.agent_url}/revocation/revoke",
+            headers=self.headers,
+            json=AnonCredsRevocation(
+                connection_id=connection_id,
+                cred_ex_id=cred_ex_id,
+                notify_version="v1_0",
+            ).model_dump(),
+        )
+        if r.status_code != 200:
+            raise Exception(r.content)

--- a/load-agent/agents/issuer/base.py
+++ b/load-agent/agents/issuer/base.py
@@ -1,20 +1,27 @@
+from abc import abstractmethod
 
-class BaseIssuer:
+from settings import Settings
 
-        def get_invite(self):
-                # return  {'invitation_url': , 'connection_id': }
-                raise NotImplementedError
+from ..base import BaseAgent
 
-        def is_up(self):
-                # return True/False
-                raise NotImplementedError
 
-        def issue_credential(self, connection_id):
-                # return { "connection_id": , "cred_ex_id":  ] }
-                raise NotImplementedError
+class BaseIssuer(BaseAgent):
+    def __init__(self):
+        print("BaseIssuer initialized")
+        super().__init__()
+        self.label = "Test Issuer"
+        self.agent_url = Settings.ISSUER_URL
+        self.headers = Settings.ISSUER_HEADERS | {"Content-Type": "application/json"}
+        self.schema_id = Settings.SCHEMA_ID
+        self.cred_def_id = Settings.CRED_DEF_ID
+        self.cred_attributes = Settings.CRED_ATTR
 
-        def revoke_credential(self, connection_id, credential_exchange_id):
-                raise NotImplementedError
+    @abstractmethod
+    def issue_credential(self, connection_id):
+        # return { "connection_id": , "cred_ex_id":  ] }
+        raise NotImplementedError
 
-        def send_message(self, connection_id, msg):
-                raise NotImplementedError
+    @abstractmethod
+    def revoke_credential(self, connection_id, credential_exchange_id):
+        raise NotImplementedError
+

--- a/load-agent/agents/verifier/acapy.py
+++ b/load-agent/agents/verifier/acapy.py
@@ -1,152 +1,101 @@
-from .base import BaseVerifier
-import requests
 import time
-from models import RequestPresentationV1, ProofRequest
-from settings import Settings
-
 from json.decoder import JSONDecodeError
 
+import requests
+from models import ProofRequest, RequestPresentationV1
+from settings import Settings
+
+from .base import BaseVerifier
+
+
 class AcapyVerifier(BaseVerifier):
-        def __init__(self):
-                self.label = "Test Verifier"
-                self.agent_url = Settings.VERIFIER_URL
-                self.headers = Settings.VERIFIER_HEADERS | {
-                        'Content-Type': 'application/json'
-                }
-        
-                self.verifiedTimeoutSeconds = Settings.VERIFIED_TIMEOUT_SECONDS
-                self.proof_request = ProofRequest(
-                        name='PerfScore',
-                        requested_attributes={
-                                item["name"]: {"name": item["name"]}
-                                for item in Settings.CRED_ATTR
-                        },
-                        requested_predicates={},
-                        version='1.0'
-                )
+    def __init__(self):
+        super().__init__()
+        self.proof_request = ProofRequest(
+            name="PerfScore",
+            requested_attributes={
+                item["name"]: {"name": item["name"]} for item in Settings.CRED_ATTR
+            },
+            requested_predicates={},
+            version="1.0",
+        )
 
-        def get_invite(self):
-                r = requests.post(
-                        f"{self.agent_url}/out-of-band/create-invitation?auto_accept=true", 
-                        json={
-                        "handshake_protocols": Settings.HANDSHAKE_PROTOCOLS
-                        },
-                        headers=self.headers
-                )
-                invitation = r.json()
+    def create_connectionless_request(self):
+        # Calling verification agent
 
+        # API call to /present-proof/create-request
+        r = requests.post(
+            f"{self.agent_url}/present-proof/create-request",
+            json=RequestPresentationV1(
+                comment="Performance Verification", proof_request=self.proof_request
+            ).model_dump(),
+            headers=self.headers,
+        )
+
+        try:
+            if r.status_code != 200:
+                raise Exception("Request was not successful: ", r.content)
+            presentation_request = r.json()
+        except JSONDecodeError:
+            raise Exception(
+                "Encountered JSONDecodeError while parsing the request: ", r.text
+            )
+
+        return presentation_request
+
+    def request_verification(self, connection_id):
+        # From verification side
+        # Might need to change nonce
+        # TO DO: Generalize schema parts
+        r = requests.post(
+            f"{self.agent_url}/present-proof/send-request",
+            json=RequestPresentationV1(
+                comment="Performance Verification",
+                connection_id=connection_id,
+                proof_request=self.proof_request,
+            ).model_dump(),
+            headers=self.headers,
+        )
+
+        try:
+            if r.status_code != 200:
+                raise Exception("Request was not successful: ", r.content)
+            presentation_request = r.json()
+        except JSONDecodeError:
+            raise Exception(
+                "Encountered JSONDecodeError while parsing the request: ", r.text
+            )
+
+        return presentation_request
+
+    def verify_verification(self, presentation_exchange_id):
+        # Want to do a for loop
+        iteration = 0
+        try:
+            while iteration < self.verifiedTimeoutSeconds:
                 r = requests.get(
-                        f"{self.agent_url}/connections",
-                        params={"invitation_msg_id": invitation['invi_msg_id']},
-                        headers=self.headers,
+                    f"{self.agent_url}/present-proof/records/{presentation_exchange_id}",
+                    headers=self.headers,
                 )
-                connection = r.json()['results'][0]
-                
-                return {
-                        'invitation_url': invitation['invitation_url'], 
-                        'connection_id': connection['connection_id']
-                }
+                presentation_record = r.json()
+                presentation_state = presentation_record["state"]
+                if (
+                    presentation_state != "request_sent"
+                    and presentation_state != "presentation_received"
+                ):
+                    "request_sent" and presentation_state != "presentation_received"
+                    break
+                iteration += 1
+                time.sleep(1)
 
-        def is_up(self):
-                try:
-                        r = requests.get(
-                                f"{self.agent_url}/status",
-                                headers=self.headers,
-                        )
-                        if r.status_code != 200:
-                                raise Exception(r.content)
-
-                        r.json()
-                except:
-                        return False
-
-                return True
-
-        def create_connectionless_request(self):
-                # Calling verification agent
-
-                # API call to /present-proof/create-request
-                r = requests.post(
-                        f"{self.agent_url}/present-proof/create-request",
-                        json=RequestPresentationV1(
-                                comment='Performance Verification',
-                                proof_request=self.proof_request
-                        ).model_dump(),
-                        headers=self.headers,
+            if presentation_record["verified"] != "true":
+                raise AssertionError(
+                    f"Presentation was not successfully verified. Presentation in state {presentation_state}"
                 )
 
-                try:
-                        if r.status_code != 200:
-                                raise Exception("Request was not successful: ", r.content)
-                        presentation_request = r.json()
-                except JSONDecodeError:
-                        raise Exception(
-                                "Encountered JSONDecodeError while parsing the request: ", r.text
-                        )
-                
-                return presentation_request
-        
-        def request_verification(self, connection_id):
-                # From verification side
-                # Might need to change nonce
-                # TO DO: Generalize schema parts
-                r = requests.post(
-                        f"{self.agent_url}/present-proof/send-request",
-                        json=RequestPresentationV1(
-                                comment='Performance Verification',
-                                connection_id=connection_id,
-                                proof_request=self.proof_request
-                        ).model_dump(),
-                        headers=self.headers,
-                )
+        except JSONDecodeError as e:
+            raise Exception(
+                "Encountered JSONDecodeError while getting the presentation record: ", e
+            )
 
-                try:
-                        if r.status_code != 200:
-                                raise Exception("Request was not successful: ", r.content)
-                        presentation_request = r.json()
-                except JSONDecodeError:
-                        raise Exception(
-                                "Encountered JSONDecodeError while parsing the request: ", r.text
-                        )
-
-                return presentation_request
-
-        def verify_verification(self, presentation_exchange_id):
-                # Want to do a for loop
-                iteration = 0
-                try:
-                        while iteration < self.verifiedTimeoutSeconds:
-                                r = requests.get(
-                                        f"{self.agent_url}/present-proof/records/{presentation_exchange_id}",
-                                        headers=self.headers,
-                                )
-                                presentation_record = r.json()
-                                presentation_state = presentation_record["state"]
-                                if (
-                                        presentation_state != "request_sent"
-                                        and presentation_state != "presentation_received"
-                                ):
-                                        "request_sent" and presentation_state != "presentation_received"
-                                        break
-                                iteration += 1
-                                time.sleep(1)
-
-                        if presentation_record["verified"] != "true":
-                                raise AssertionError(
-                                        f"Presentation was not successfully verified. Presentation in state {presentation_state}"
-                                )
-
-                except JSONDecodeError as e:
-                        raise Exception(
-                                "Encountered JSONDecodeError while getting the presentation record: ", e
-                        )
-
-                return True
-
-        def send_message(self, connection_id, msg):
-                r = requests.post(
-                        f"{self.agent_url}/connections/{connection_id}/send-message",
-                        json={"content": msg},
-                        headers=self.headers,
-                )
-                r.json()
+        return True

--- a/load-agent/agents/verifier/acapy_v2.py
+++ b/load-agent/agents/verifier/acapy_v2.py
@@ -1,0 +1,99 @@
+import time
+from json.decoder import JSONDecodeError
+
+import requests
+from models import AnonCredsPresReq, ProofRequest
+from models import RequestPresentationV2 as RequestPresentation
+from settings import Settings
+
+from .base import BaseVerifier
+
+
+class AcapyVerifier(BaseVerifier):
+    def __init__(self):
+        self.filter = Settings.FILTER_TYPE
+        self.cred_attributes = Settings.CRED_ATTR
+
+    def create_connectionless_request(self):
+        r = requests.post(
+            f"{self.agent_url}/present-proof-2.0/send-request",
+            headers=self.headers,
+            json=RequestPresentation(
+                proof_request=AnonCredsPresReq(
+                    anoncreds=ProofRequest(
+                        name="PerfScore",
+                        requested_attributes={
+                            item["name"]: {"name": item["name"]}
+                            for item in self.cred_attributes
+                        },
+                        requested_predicates={},
+                        version="1.0",
+                    )
+                ),
+            ).model_dump(),
+        )
+        if r.status_code != 200:
+            raise Exception("Request was not successful: ", r.content)
+        try:
+            return r.json()
+        except JSONDecodeError:
+            raise Exception(
+                "Encountered JSONDecodeError while parsing the request: ", r.text
+            )
+
+    def request_verification(self, connection_id):
+        r = requests.post(
+            f"{self.agent_url}/present-proof-2.0/send-request",
+            headers=self.headers,
+            json=RequestPresentation(
+                connection_id=connection_id,
+                proof_request=AnonCredsPresReq(
+                    anoncreds=ProofRequest(
+                        name="PerfScore",
+                        requested_attributes={
+                            item["name"]: {"name": item["name"]}
+                            for item in self.cred_attributes
+                        },
+                        requested_predicates={},
+                        version="1.0",
+                    )
+                ),
+            ).model_dump(),
+        )
+        if r.status_code != 200:
+            raise Exception("Request was not successful: ", r.content)
+
+        try:
+            return r.json()["presentation_exchange_id"]
+        except JSONDecodeError:
+            raise Exception(
+                "Encountered JSONDecodeError while parsing the request: ", r.text
+            )
+
+    def verify_verification(self, pres_ex_id):
+        # Want to do a for loop
+        try:
+            for iteration in range(self.verifiedTimeoutSeconds):
+                r = requests.get(
+                    f"{self.agent_url}/present-proof-2.0/records/{pres_ex_id}",
+                    headers=self.headers,
+                )
+                if (
+                    r.json()["state"] != "request_sent"
+                    and r.json()["state"] != "presentation_received"
+                ):
+                    "request_sent" and r.json()["state"] != "presentation_received"
+                    break
+                time.sleep(1)
+
+            if r.json()["verified"] != "true":
+                raise AssertionError(
+                    f"Presentation was not successfully verified. Presentation in state {r.json()['state']}"
+                )
+
+            return True
+
+        except JSONDecodeError as e:
+            raise Exception(
+                "Encountered JSONDecodeError while getting the presentation record: ", e
+            )

--- a/load-agent/agents/verifier/base.py
+++ b/load-agent/agents/verifier/base.py
@@ -1,21 +1,26 @@
+from abc import abstractmethod
 
-class BaseVerifier:
-        def get_invite(self):
-                # return  {'invitation_url': , 'connection_id': }
-                raise NotImplementedError
+from settings import Settings
 
-        def is_up(self):
-                # return True/False
-                raise NotImplementedError
+from ..base import BaseAgent
 
-        def request_verification(self, connection_id):
-                # return r['presentation_exchange_id']
-                raise NotImplementedError
 
-        def verify_verification(self, presentation_exchange_id):
-                # return True on success
-                # Throw Exception on failure
-                raise NotImplementedError
+class BaseVerifier(BaseAgent):
+    def __init__(self):
+        print("BaseVerifier initialized")
+        super().__init__()
+        self.label = "Test Verifier"
+        self.agent_url = Settings.VERIFIER_URL
+        self.headers = Settings.VERIFIER_HEADERS | {"Content-Type": "application/json"}
+        self.verifiedTimeoutSeconds = Settings.VERIFIED_TIMEOUT_SECONDS
 
-        def send_message(self, connection_id, msg):
-                raise NotImplementedError
+    @abstractmethod
+    def request_verification(self, connection_id):
+        # return r['presentation_exchange_id']
+        raise NotImplementedError
+
+    @abstractmethod
+    def verify_verification(self, presentation_exchange_id):
+        # return True on success
+        # Throw Exception on failure
+        raise NotImplementedError

--- a/load-agent/locust-files/locustLiveness.py
+++ b/load-agent/locust-files/locustLiveness.py
@@ -1,6 +1,7 @@
-from locust import SequentialTaskSet, task, User, between
-from locustClient import CustomClient
 from constants import standard_wait
+from locust import SequentialTaskSet, User, task
+from locustClient import CustomClient
+
 
 class CustomLocust(User):
     abstract = True
@@ -22,4 +23,3 @@ class UserBehaviour(SequentialTaskSet):
 class Liveness(CustomLocust):
     tasks = [UserBehaviour]
     wait_time = standard_wait
-#    host = "example.com"

--- a/load-agent/locust-files/locustMediatorIssue.py
+++ b/load-agent/locust-files/locustMediatorIssue.py
@@ -1,8 +1,8 @@
-from locust import SequentialTaskSet, task, User, between
-from locustClient import CustomClient
-from constants import standard_wait
-
 import os
+
+from constants import standard_wait
+from locust import SequentialTaskSet, User, task
+from locustClient import CustomClient
 
 WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
@@ -28,16 +28,14 @@ class UserBehaviour(SequentialTaskSet):
     def accept_invite(self):
         self.client.ensure_is_running()
 
-        connection = self.client.accept_invite(self.invite['invitation_url'])
-        self.connection = connection
+        self.connection = self.client.accept_invite(self.invite['invitation_url'])
 
     @task
     def receive_credential(self):
         self.client.ensure_is_running()
 
-        credential = self.client.receive_credential(self.invite['connection_id'])
+        self.client.receive_credential(self.invite['connection_id'])
 
 class Issue(CustomLocust):
     tasks = [UserBehaviour]
     wait_time = standard_wait
-#    host = "example.com"

--- a/load-agent/models/__init__.py
+++ b/load-agent/models/__init__.py
@@ -1,9 +1,21 @@
-from .protocols import AnonCredsRevocation, CredentialProposalV1, IssueCredentialV1, RequestPresentationV1, ProofRequest
+from .protocols import AnonCredsRevocation, ProofRequest
+from .protocols import CredentialProposal as CredentialProposalV1
+from .protocols import IssueCredential as IssueCredentialV1
+from .protocols import RequestPresentation as RequestPresentationV1
+from .protocols_v2 import AnonCredsFilter, AnonCredsPresReq, CredentialPreview, Filter
+from .protocols_v2 import IssueCredential as IssueCredentialV2
+from .protocols_v2 import RequestPresentation as RequestPresentationV2
 
 __all__ = [
     "IssueCredentialV1",
     "RequestPresentationV1",
     "CredentialProposalV1",
+    "IssueCredentialV2",
+    "RequestPresentationV2",
+    "CredentialPreview",
+    "AnonCredsFilter",
+    "Filter",
     "ProofRequest",
     "AnonCredsRevocation",
+    "AnonCredsPresReq"
 ]

--- a/load-agent/models/protocols.py
+++ b/load-agent/models/protocols.py
@@ -1,5 +1,6 @@
+from typing import Any, Dict
+
 from pydantic import BaseModel, Field
-from typing import Dict, Any
 
 
 class BaseModel(BaseModel):
@@ -7,17 +8,17 @@ class BaseModel(BaseModel):
         return super().model_dump(by_alias=True, exclude_none=True, **kwargs)
 
 
-class CredentialProposalV1(BaseModel):
+class CredentialProposal(BaseModel):
     type: str = Field('issue-credential/1.0/credential-preview', alias='@type')
     attributes: list = Field()
 
 
-class IssueCredentialV1(BaseModel):
+class IssueCredential(BaseModel):
     auto_remove: bool = Field(True)
     comment: str = Field()
     connection_id: str = Field()
     cred_def_id: str = Field()
-    credential_proposal: CredentialProposalV1 = Field()
+    credential_proposal: CredentialProposal = Field()
     issuer_did: str = Field()
     schema_id: str = Field()
     schema_issuer_did: str = Field()
@@ -33,7 +34,7 @@ class ProofRequest(BaseModel):
     version: str = Field()
 
 
-class RequestPresentationV1(BaseModel):
+class RequestPresentation(BaseModel):
     auto_remove: bool = Field(False)
     auto_verify: bool = Field(True)
     connection_id: str = Field(None)

--- a/load-agent/models/protocols_v2.py
+++ b/load-agent/models/protocols_v2.py
@@ -1,0 +1,47 @@
+from typing import Any, Dict, Union
+
+from pydantic import BaseModel, Field
+
+
+class BaseModel(BaseModel):
+    def model_dump(self, **kwargs) -> Dict[str, Any]:
+        return super().model_dump(by_alias=True, exclude_none=True, **kwargs)
+
+class CredentialPreview(BaseModel):
+    type: str = Field('issue-credential/2.0/credential-preview', alias='@type')
+    attributes: list = Field()
+
+class Filter(BaseModel):
+    cred_def_id: str = Field()
+
+class AnonCredsFilter(BaseModel):
+    anoncreds: Filter = Field()
+
+class IndyFilter(BaseModel):
+    indy: Filter = Field()
+
+class IssueCredential(BaseModel):
+    connection_id: str = Field()
+    credential_preview: CredentialPreview = Field()
+    filter: Union[AnonCredsFilter, IndyFilter] = Field()
+
+class ProofRequest(BaseModel):
+    name: str = Field()
+    requested_attributes: dict = Field()
+    requested_predicates: dict = Field()
+    version: str = Field()
+
+class AnonCredsPresReq(BaseModel):
+    anoncreds: ProofRequest = Field()
+
+class DifPresReq(BaseModel):
+    dif: dict = Field()
+
+class IndyPresReq(BaseModel):
+    indy: ProofRequest = Field()
+
+class RequestPresentation(BaseModel):
+    auto_verify: bool = Field(True)
+    auto_remove: bool = Field(True)
+    connection_id: str = Field(None)
+    presentation_request: Union[AnonCredsPresReq, DifPresReq, IndyPresReq] = Field()

--- a/load-agent/settings.py
+++ b/load-agent/settings.py
@@ -10,6 +10,9 @@ class Settings(object):
     START_PORT = json.loads(os.getenv("START_PORT"))
     END_PORT = json.loads(os.getenv("END_PORT"))
     
+    # FILTER_TYPE
+    FILTER_TYPE= os.getenv("FILTER_TYPE", "anoncreds")
+    
     # Load test data
     SCHEMA_ID: str = os.getenv("SCHEMA")
     CRED_DEF_ID: str = os.getenv("CRED_DEF")

--- a/sample.env
+++ b/sample.env
@@ -44,3 +44,5 @@ MESSAGE_TO_SEND="Lorem ipsum dolor sit amet consectetur, adipiscing elit nisi ap
 # If you want to use a different pickup strategy, you can set it here
 # The default is 'implicit', but you can also use 'pickupv2-live'
 PICKUP_STRATEGY='implicit' # or 'pickupv2-live'
+
+FILTER_TYPE="anoncreds"


### PR DESCRIPTION
This work was originally started by @PatStLouis .

It creates an abstract base agent and abstract issue/verifier agents and then separate acapy agents for the legacy v1 issuance and presentation endpoints and the new v2 endpoints. This allows you decide which agent to use simply with the ISSUER_TYPE env variable. It also prevents the code from trying to do this from a single agent with many conditionals and keeps the code clean.