### PR TITLE
Add credo agent logging support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - WITH_MEDIATION=${WITH_MEDIATION}
       - PICKUP_STRATEGY=${PICKUP_STRATEGY}
       - IS_ANONCREDS=${IS_ANONCREDS}
+      - AGENT_LOGGING_LEVEL=${AGENT_LOGGING_LEVEL}
     networks:
       - app-network
 

--- a/load-agent/agent.ts
+++ b/load-agent/agent.ts
@@ -43,6 +43,8 @@ import {
   CredentialState,
   ProofState,
   BasicMessageEventTypes,
+  ConsoleLogger,
+  LogLevel,
 } from '@credo-ts/core'
 import { anoncreds } from '@hyperledger/anoncreds-nodejs'
 import { ariesAskar } from '@hyperledger/aries-askar-nodejs'
@@ -77,6 +79,10 @@ const initializeAgent = async (withMediation, port, agentConfig = null) => {
   let mediation_url = config.mediation_url
   let endpoints = ['http://' + config.agent_ip + ':' + port]
 
+  const logLevel = parseInt(process.env.AGENT_LOGGING_LEVEL) || LogLevel.off
+
+  process.stderr.write('Agent Log Level: ' + parseInt(process.env.AGENT_LOGGING_LEVEL) + '\n')
+
   if (!agentConfig || agentConfig === null || agentConfig.length === 0) {
     agentConfig = {
       label: generateString(14),
@@ -88,7 +94,7 @@ const initializeAgent = async (withMediation, port, agentConfig = null) => {
       endpoints: endpoints,
       mediation_url:mediation_url,
       autoAcceptInvitation: true,
-      // logger: new ConsoleLogger(LogLevel.trace),
+      logger: new ConsoleLogger(logLevel),
       didCommMimeType: DidCommMimeType.V1,
     }
   }

--- a/sample.env
+++ b/sample.env
@@ -46,3 +46,5 @@ MESSAGE_TO_SEND="Lorem ipsum dolor sit amet consectetur, adipiscing elit nisi ap
 PICKUP_STRATEGY="implicit" # or 'pickupv2-live'
 
 IS_ANONCREDS="True" # Set to True if using AnonCreds, False for Indy Creds
+
+AGENT_LOGGING_LEVEL=7 # Set to a credo LogLevel, e.g. 7 for off, 3 for info, etc.


### PR DESCRIPTION
This is a PR to add logging capabilities to the credo agents. This will get quite mixed up if running multiple agents and for that reason it defaults to level 7, or off. Still, this is very handy for debugging why a test is having issues and why a credo agent is failing.