### PR TITLE
Locustfile abstraction and connections per agent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - PICKUP_STRATEGY=${PICKUP_STRATEGY}
       - IS_ANONCREDS=${IS_ANONCREDS}
       - AGENT_LOGGING_LEVEL=${AGENT_LOGGING_LEVEL}
+      - CONNECTIONS_PER_AGENT=${CONNECTIONS_PER_AGENT}
     networks:
       - app-network
 

--- a/load-agent/constants.py
+++ b/load-agent/constants.py
@@ -1,4 +1,13 @@
-from locust import between
 import os
+import random
 
-standard_wait = between(float(os.getenv('LOCUST_MIN_WAIT', 0.1)), float(os.getenv('LOCUST_MAX_WAIT', 1)))
+from locust import between
+
+min_wait = float(os.getenv("LOCUST_MIN_WAIT", 0.1))
+max_wait = float(os.getenv("LOCUST_MAX_WAIT", 1))
+
+standard_wait = between(min_wait, max_wait)
+
+# Equivalent to locust.between
+def deviation_wait(a: float, b: float) -> float:
+    return random.uniform(a, b)

--- a/load-agent/constants.py
+++ b/load-agent/constants.py
@@ -9,5 +9,5 @@ max_wait = float(os.getenv("LOCUST_MAX_WAIT", 1))
 standard_wait = between(min_wait, max_wait)
 
 # Equivalent to locust.between
-def deviation_wait(a: float, b: float) -> float:
-    return random.uniform(a, b)
+def deviation_wait() -> float:
+    return random.uniform(min_wait, max_wait)

--- a/load-agent/locust-files/locustConnection.py
+++ b/load-agent/locust-files/locustConnection.py
@@ -1,0 +1,31 @@
+import os
+
+from constants import standard_wait
+from locust import SequentialTaskSet, task
+from locustCustom import CustomLocust
+
+WITH_MEDIATION = os.getenv("WITH_MEDIATION")
+NUMBER_OF_CONNECTIONS = int(os.getenv("CONNECTIONS_PER_AGENT", 1))
+
+
+class ConnectionUserBehaviour(SequentialTaskSet):
+    def on_start(self):
+        # Start up the client with or without mediation once per user
+        self.client.startup(withMediation=bool(WITH_MEDIATION))
+        self.invites = []
+
+    def on_stop(self):
+        self.client.shutdown()
+
+    @task
+    def establish_connections(self):
+        if len(self.invites) < NUMBER_OF_CONNECTIONS:
+            self.client.ensure_is_running()
+            invite = self.client.issuer_getinvite()
+            self.client.accept_invite(invite["invitation_url"])
+            self.invites.append(invite)
+
+
+class Issue(CustomLocust):
+    tasks = [ConnectionUserBehaviour]
+    wait_time = standard_wait

--- a/load-agent/locust-files/locustCustom.py
+++ b/load-agent/locust-files/locustCustom.py
@@ -1,0 +1,10 @@
+from locust import User
+from locustClient import CustomClient
+
+
+class CustomLocust(User):
+    abstract = True
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.client = CustomClient(self.host)

--- a/load-agent/locust-files/locustFractionMediatorIssueVerify.py
+++ b/load-agent/locust-files/locustFractionMediatorIssueVerify.py
@@ -1,52 +1,36 @@
 import os
+import time
 
-from constants import standard_wait
-from locust import SequentialTaskSet, User, task
-from locustClient import CustomClient
+from constants import deviation_wait, standard_wait
+from locust import task
+from locustConnection import ConnectionUserBehaviour
+from locustCustom import CustomLocust
 
 WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
-class CustomLocust(User):
-    abstract = True
+
+class UserBehaviour(ConnectionUserBehaviour):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args,**kwargs)
-        self.client = CustomClient(self.host)
-
-class UserBehaviour(SequentialTaskSet):
-    def on_start(self):
-        self.client.startup(withMediation=bool(WITH_MEDIATION))
-
-    def on_stop(self):
-        self.client.shutdown()
-
-    @task
-    def get_invite(self):
-        invite = self.client.issuer_getinvite()
-        self.invite = invite
-
-    @task
-    def accept_invite(self):
-        self.client.ensure_is_running()
-
-        connection = self.client.accept_invite(self.invite['invitation_url'])
-        if connection is not None:
-            self.connection = connection
+        super().__init__(*args, **kwargs)
 
     @task(3)
     def receive_credential(self):
         self.client.ensure_is_running()
 
-        self.client.receive_credential(self.invite['connection_id'])
+        for invite in self.invites:
+            self.client.receive_credential(invite["connection_id"])
+            time.sleep(deviation_wait(0.1, 0.3))
 
     @task(1)
     def presentation_exchange(self):
         self.client.ensure_is_running()
 
         # Need connection id
-        self.client.presentation_exchange(self.invite['connection_id'])
+        for invite in self.invites:
+            self.client.presentation_exchange(invite["connection_id"])
+            time.sleep(deviation_wait(0.1, 0.3))
 
 
 class Issue(CustomLocust):
     tasks = [UserBehaviour]
     wait_time = standard_wait
-

--- a/load-agent/locust-files/locustFractionMediatorIssueVerify.py
+++ b/load-agent/locust-files/locustFractionMediatorIssueVerify.py
@@ -19,7 +19,7 @@ class UserBehaviour(ConnectionUserBehaviour):
 
         for invite in self.invites:
             self.client.receive_credential(invite["connection_id"])
-            time.sleep(deviation_wait(0.1, 0.3))
+            time.sleep(deviation_wait())
 
     @task(1)
     def presentation_exchange(self):
@@ -28,7 +28,7 @@ class UserBehaviour(ConnectionUserBehaviour):
         # Need connection id
         for invite in self.invites:
             self.client.presentation_exchange(invite["connection_id"])
-            time.sleep(deviation_wait(0.1, 0.3))
+            time.sleep(deviation_wait())
 
 
 class Issue(CustomLocust):

--- a/load-agent/locust-files/locustLiveness.py
+++ b/load-agent/locust-files/locustLiveness.py
@@ -1,13 +1,7 @@
 from constants import standard_wait
-from locust import SequentialTaskSet, User, task
-from locustClient import CustomClient
+from locust import SequentialTaskSet, task
+from locustCustom import CustomLocust
 
-
-class CustomLocust(User):
-    abstract = True
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args,**kwargs)
-        self.client = CustomClient(self.host)
 
 class UserBehaviour(SequentialTaskSet):
     def on_start(self):
@@ -19,6 +13,7 @@ class UserBehaviour(SequentialTaskSet):
     @task
     def get_liveness(self):
         self.client.issuer_getliveness()
+
 
 class Liveness(CustomLocust):
     tasks = [UserBehaviour]

--- a/load-agent/locust-files/locustMediatorIssue.py
+++ b/load-agent/locust-files/locustMediatorIssue.py
@@ -15,7 +15,7 @@ class UserBehaviour(ConnectionUserBehaviour):
         self.client.ensure_is_running()
         for invite in self.invites:
             self.client.receive_credential(invite["connection_id"])
-            time.sleep(deviation_wait(0.1, 0.3))
+            time.sleep(deviation_wait())
 
 
 class Issue(CustomLocust):

--- a/load-agent/locust-files/locustMediatorIssue.py
+++ b/load-agent/locust-files/locustMediatorIssue.py
@@ -1,41 +1,22 @@
-import os
+import time
 
-from constants import standard_wait
-from locust import SequentialTaskSet, User, task
-from locustClient import CustomClient
+from constants import deviation_wait, standard_wait
+from locust import task
+from locustConnection import ConnectionUserBehaviour
+from locustCustom import CustomLocust
 
-WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
-class CustomLocust(User):
-    abstract = True
+class UserBehaviour(ConnectionUserBehaviour):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args,**kwargs)
-        self.client = CustomClient(self.host)
-
-class UserBehaviour(SequentialTaskSet):
-    def on_start(self):
-        self.client.startup(withMediation=bool(WITH_MEDIATION))
-
-    def on_stop(self):
-        self.client.shutdown()
-
-    @task
-    def get_invite(self):
-        invite = self.client.issuer_getinvite()
-        self.invite = invite
-
-    @task
-    def accept_invite(self):
-        self.client.ensure_is_running()
-        connection = self.client.accept_invite(self.invite['invitation_url'])
-        if connection is not None:
-            self.connection = connection
+        super().__init__(*args, **kwargs)
 
     @task
     def receive_credential(self):
         self.client.ensure_is_running()
+        for invite in self.invites:
+            self.client.receive_credential(invite["connection_id"])
+            time.sleep(deviation_wait(0.1, 0.3))
 
-        self.client.receive_credential(self.invite['connection_id'])
 
 class Issue(CustomLocust):
     tasks = [UserBehaviour]

--- a/load-agent/locust-files/locustMediatorIssueRevoke.py
+++ b/load-agent/locust-files/locustMediatorIssueRevoke.py
@@ -19,7 +19,7 @@ class UserBehaviour(ConnectionUserBehaviour):
             self.credentials.append(
                 self.client.receive_credential(invite["connection_id"])
             )
-            time.sleep(deviation_wait(0.1, 0.3))
+            time.sleep(deviation_wait())
 
     @task
     def revoke_credential(self):

--- a/load-agent/locust-files/locustMediatorIssueRevoke.py
+++ b/load-agent/locust-files/locustMediatorIssueRevoke.py
@@ -1,48 +1,33 @@
-import os
+import time
 
-from constants import standard_wait
-from locust import SequentialTaskSet, User, task
-from locustClient import CustomClient
+from constants import deviation_wait, standard_wait
+from locust import task
+from locustConnection import ConnectionUserBehaviour
+from locustCustom import CustomLocust
 
-WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
-class CustomLocust(User):
-    abstract = True
+class UserBehaviour(ConnectionUserBehaviour):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args,**kwargs)
-        self.client = CustomClient(self.host)
-
-class UserBehaviour(SequentialTaskSet):
-    def on_start(self):
-        self.client.startup(withMediation=bool(WITH_MEDIATION))
-
-    def on_stop(self):
-        self.client.shutdown()
-
-    @task
-    def get_invite(self):
-        invite = self.client.issuer_getinvite()
-        self.invite = invite
-
-    @task
-    def accept_invite(self):
-        self.client.ensure_is_running()
-
-        connection = self.client.accept_invite(self.invite['invitation_url'])
-        if connection is not None:
-            self.connection = connection
+        super().__init__(*args, **kwargs)
+        self.credentials = []
 
     @task
     def receive_credential(self):
         self.client.ensure_is_running()
 
-        self.credential = self.client.receive_credential(self.invite['connection_id'])
+        for invite in self.invites:
+            self.credentials.append(
+                self.client.receive_credential(invite["connection_id"])
+            )
+            time.sleep(deviation_wait(0.1, 0.3))
 
     @task
     def revoke_credential(self):
         self.client.ensure_is_running()
 
-        self.client.revoke_credential(self.credential)
+        for credential in self.credentials:
+            self.client.revoke_credential(credential)
+
 
 class IssueRevoke(CustomLocust):
     tasks = [UserBehaviour]

--- a/load-agent/locust-files/locustMediatorMsg.py
+++ b/load-agent/locust-files/locustMediatorMsg.py
@@ -1,44 +1,19 @@
-import os
-
 from constants import standard_wait
-from locust import SequentialTaskSet, User, task
-from locustClient import CustomClient
+from locust import task
+from locustConnection import ConnectionUserBehaviour
+from locustCustom import CustomLocust
 
-WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
-class CustomLocust(User):
-    abstract = True
+class UserBehaviour(ConnectionUserBehaviour):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args,**kwargs)
-        self.client = CustomClient(self.host)
-
-class UserBehaviour(SequentialTaskSet):
-    def on_start(self):
-        while not self.client.is_running():
-            self.client.startup(withMediation=bool(WITH_MEDIATION))
-
-        self.get_invite()
-
-        self.accept_invite()
-
-    def get_invite(self):
-        invite = self.client.issuer_getinvite()
-        self.invite = invite
-
-    def accept_invite(self):
-        self.client.ensure_is_running()
-
-        connection = self.client.accept_invite(self.invite['invitation_url'])
-        if connection is not None:
-            self.connection = connection
-
-    def on_stop(self):
-        self.client.shutdown()
+        super().__init__(*args, **kwargs)
 
     @task
     def msg_client(self):
         # I think this should be @id....
-        self.client.msg_client(self.invite['connection_id'])
+        for invite in self.invites:
+            self.client.msg_client(invite["connection_id"])
+
 
 class MediatorMsg(CustomLocust):
     tasks = [UserBehaviour]

--- a/load-agent/locust-files/locustMediatorPing.py
+++ b/load-agent/locust-files/locustMediatorPing.py
@@ -1,21 +1,16 @@
 import os
 
 from constants import standard_wait
-from locust import TaskSet, User, task
-from locustClient import CustomClient
+from locust import TaskSet, task
+from locustCustom import CustomLocust
 
 WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
-class CustomLocust(User):
-    abstract = True
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args,**kwargs)
-        self.client = CustomClient(self.host)
 
 class UserBehaviour(TaskSet):
     def on_start(self):
         self.client.startup(withMediation=bool(WITH_MEDIATION))
-        
+
     def on_stop(self):
         self.client.shutdown()
 
@@ -24,6 +19,7 @@ class UserBehaviour(TaskSet):
         self.client.ensure_is_running()
 
         self.client.ping_mediator()
+
 
 class MediatorPing(CustomLocust):
     tasks = [UserBehaviour]

--- a/load-agent/locust-files/locustMediatorPresentProof.py
+++ b/load-agent/locust-files/locustMediatorPresentProof.py
@@ -15,7 +15,7 @@ class UserBehaviour(ConnectionUserBehaviour):
         self.client.ensure_is_running()
         for invite in self.invites:
             self.client.receive_credential(invite["connection_id"])
-            time.sleep(deviation_wait(0.1, 0.3))
+            time.sleep(deviation_wait())
 
     @task
     def get_verifier_invite(self):

--- a/load-agent/locust-files/locustMediatorPresentProof.py
+++ b/load-agent/locust-files/locustMediatorPresentProof.py
@@ -1,41 +1,21 @@
-import os
+import time
 
-from constants import standard_wait
-from locust import SequentialTaskSet, User, task
-from locustClient import CustomClient
+from constants import deviation_wait, standard_wait
+from locust import task
+from locustConnection import ConnectionUserBehaviour
+from locustCustom import CustomLocust
 
-WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
-class CustomLocust(User):
-    abstract = True
+class UserBehaviour(ConnectionUserBehaviour):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args,**kwargs)
-        self.client = CustomClient(self.host)
-
-class UserBehaviour(SequentialTaskSet):
-    def on_start(self):
-        self.client.startup(withMediation=bool(WITH_MEDIATION))
-
-    def on_stop(self):
-        self.client.shutdown()
-
-    @task
-    def get_issuer_invite(self):
-        invite = self.client.issuer_getinvite()
-        self.invite = invite
-
-    @task
-    def accept_issuer_invite(self):
-        self.client.ensure_is_running()
-
-        connection = self.client.accept_invite(self.invite['invitation_url'])
-        if connection is not None:
-            self.connection = connection
+        super().__init__(*args, **kwargs)
 
     @task
     def receive_credential(self):
         self.client.ensure_is_running()
-        self.client.receive_credential(self.invite['connection_id'])
+        for invite in self.invites:
+            self.client.receive_credential(invite["connection_id"])
+            time.sleep(deviation_wait(0.1, 0.3))
 
     @task
     def get_verifier_invite(self):
@@ -46,17 +26,18 @@ class UserBehaviour(SequentialTaskSet):
     def accept_verifier_invite(self):
         self.client.ensure_is_running()
 
-        verifier_connection = self.client.accept_invite(self.verifier_invite['invitation_url'])
+        verifier_connection = self.client.accept_invite(
+            self.verifier_invite["invitation_url"]
+        )
         if verifier_connection is not None:
             self.verifier_connection = verifier_connection
 
     @task
     def presentation_exchange(self):
         self.client.ensure_is_running()
-        self.client.presentation_exchange(self.verifier_invite['connection_id'])
+        self.client.presentation_exchange(self.verifier_invite["connection_id"])
 
 
 class Issue(CustomLocust):
     tasks = [UserBehaviour]
     wait_time = standard_wait
-

--- a/load-agent/locust-files/locustMediatorPresentProofExisting.py
+++ b/load-agent/locust-files/locustMediatorPresentProofExisting.py
@@ -15,7 +15,7 @@ class UserBehaviour(ConnectionUserBehaviour):
         self.client.ensure_is_running()
         for invite in self.invites:
             self.client.receive_credential(invite["connection_id"])
-            time.sleep(deviation_wait(0.1, 0.3))
+            time.sleep(deviation_wait())
 
     @task
     def get_verifier_invite(self):

--- a/load-agent/locust-files/locustMediatorPresentProofExisting.py
+++ b/load-agent/locust-files/locustMediatorPresentProofExisting.py
@@ -1,56 +1,36 @@
-import os
+import time
 
-from constants import standard_wait
-from locust import SequentialTaskSet, User, task
-from locustClient import CustomClient
+from constants import deviation_wait, standard_wait
+from locust import task
+from locustConnection import ConnectionUserBehaviour
+from locustCustom import CustomLocust
 
-WITH_MEDIATION = os.getenv("WITH_MEDIATION")
 
-class CustomLocust(User):
-    abstract = True
-
+class UserBehaviour(ConnectionUserBehaviour):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.client = CustomClient(self.host)
 
-
-class UserBehaviour(SequentialTaskSet):
-    def get_invite(self):
-        invite = self.client.issuer_getinvite()
-        self.invite = invite
-
-    def accept_invite(self):
-        self.client.ensure_is_running()
-
-        connection = self.client.accept_invite(self.invite['invitation_url'])
-        if connection is not None:
-            self.connection = connection
-
+    @task
     def receive_credential(self):
         self.client.ensure_is_running()
-        self.client.receive_credential(self.invite["connection_id"])
+        for invite in self.invites:
+            self.client.receive_credential(invite["connection_id"])
+            time.sleep(deviation_wait(0.1, 0.3))
 
+    @task
     def get_verifier_invite(self):
         verifier_invite = self.client.verifier_getinvite()
         self.verifier_invite = verifier_invite
 
+    @task
     def accept_verifier_invite(self):
         self.client.ensure_is_running()
-        
-        verifier_connection = self.client.accept_invite(self.verifier_invite['invitation_url'])
+
+        verifier_connection = self.client.accept_invite(
+            self.verifier_invite["invitation_url"]
+        )
         if verifier_connection is not None:
             self.verifier_connection = verifier_connection
-
-    def on_start(self):
-        self.client.startup(withMediation=bool(WITH_MEDIATION))
-        self.get_invite()
-        self.accept_invite()
-        self.receive_credential()
-        self.get_verifier_invite()
-        self.accept_verifier_invite()
-
-    def on_stop(self):
-        self.client.shutdown()
 
     @task
     def presentation_exchange(self):

--- a/load-agent/settings.py
+++ b/load-agent/settings.py
@@ -55,3 +55,6 @@ class Settings(object):
         "https://didcomm.org/didexchange/1.0",
         "https://didcomm.org/didexchange/1.1"
     ]
+    
+    # Connections per agent
+    CONNECTIONS_PER_AGENT: int = int(os.getenv("CONNECTIONS_PER_AGENT", 1))

--- a/sample.env
+++ b/sample.env
@@ -48,3 +48,5 @@ PICKUP_STRATEGY="implicit" # or 'pickupv2-live'
 IS_ANONCREDS="True" # Set to True if using AnonCreds, False for Indy Creds
 
 AGENT_LOGGING_LEVEL=7 # Set to a credo LogLevel, e.g. 7 for off, 3 for info, etc.
+
+CONNECTIONS_PER_AGENT=2 # Number of connections per agent


### PR DESCRIPTION
This PR does a few things.
 - Defines an environment variable for the number of connections per akrida agent. This make it easier to test long standing connections and also define an exact total of connections and simultaneous issuances/presentations/revocations.
 - Separates the connections logic into an abstract `ConnectionUserBehaviour` class, this simplifies all the other locust files which create connections.
 - Adds a separate deviated wait function after issuance to prevent consistent looped spamming from a single agent on multiple connections. Slightly more realistic.