### PR TITLE
Upgrade locust to 2.38.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN cd indy-sdk/libindy && \
 
 RUN apt-get install -y python3-pip
 
-RUN pip3 install locust==2.14.2 python-dotenv pydantic
+RUN pip3 install locust==2.38.1 python-dotenv pydantic
 
 FROM base AS dev
 

--- a/Dockerfile.vdr
+++ b/Dockerfile.vdr
@@ -11,7 +11,7 @@ RUN apt-get update -y && apt-get install -y curl gcc g++ make git libssl-dev pkg
 
 RUN apt-get install -y python3-pip
 
-RUN pip3 install locust==2.14.2
+RUN pip3 install locust==3.38.1
 
 FROM base AS dev
 

--- a/load-agent/locustClient.py
+++ b/load-agent/locustClient.py
@@ -47,20 +47,21 @@ def stopwatch(func):
             result = func(*args, **kwargs)
         except Exception as e:
             total = int((time.time() - start) * 1000)
-            events.request_failure.fire(
+            events.request.fire(
                 request_type="TYPE",
-                name=file_name + "_" + task_name,
+                name=f"{file_name}_{task_name}",
                 response_time=total,
-                exception=e,
                 response_length=0,
+                exception=e,
             )
         else:
             total = int((time.time() - start) * 1000)
-            events.request_success.fire(
+            events.request.fire(
                 request_type="TYPE",
-                name=file_name + "_" + task_name,
+                name=f"{file_name}_{task_name}",
                 response_time=total,
-                response_length=0,
+                response_length=0,     # size in bytes
+                exception=None
             )
         return result
 


### PR DESCRIPTION
Pretty simple update to get locust upgraded to latest version. There's some UI improvements and an HttpUser class that we should migrate to and it has session support https://github.com/locustio/locust/blob/master/locust/user/users.py#L241